### PR TITLE
Adding support for abbreviations

### DIFF
--- a/docs/basic-routing.en.md
+++ b/docs/basic-routing.en.md
@@ -6,9 +6,6 @@ order: 1
 
 Routing determines how the application will respond to a request from a *client* at an *endpoint*, which would be the URI and a specific method of the HTTP protocol (POST, PUT, GET, DELETE and so on).
 
-*[URI]: Uniform Resource Identifier
-*[HTTP]: Hypertext Transfer Protocol
-
 On the route, it is possible to have more than one treatment, which will be executed when the route that was requested is the corresponding one.
 
 The route has the following structure:
@@ -66,3 +63,4 @@ Reply with "Hello World!" to whoever requested (*client* who made the *request*)
         Res.Send('Got a DELETE request at /user');
       end);
     ```
+--8<-- "includes/abbreviations.md"

--- a/docs/basic-routing.en.md
+++ b/docs/basic-routing.en.md
@@ -6,6 +6,9 @@ order: 1
 
 Routing determines how the application will respond to a request from a *client* at an *endpoint*, which would be the URI and a specific method of the HTTP protocol (POST, PUT, GET, DELETE and so on).
 
+*[URI]: Uniform Resource Identifier
+*[HTTP]: Hypertext Transfer Protocol
+
 On the route, it is possible to have more than one treatment, which will be executed when the route that was requested is the corresponding one.
 
 The route has the following structure:

--- a/docs/basic-routing.md
+++ b/docs/basic-routing.md
@@ -6,6 +6,9 @@ order: 1
 
 Rotas determinam como a aplicação responderá a uma requisição do *cliente* em um caminho específico chamado *endpoint*, que é uma [URI](https://pt.wikipedia.org/wiki/URI) que especifica um método do protocolo HTTP (POST, PUT, GET, DELETE e além).
 
+*[URI]: Indicador Único de Recurso  
+*[HTTP]: Protocolo de Internet  
+
 Cada rota pode ter mais de um tratamento, que responderá de acordo com a requisição correspondente.
 
 Uma rota possui a seguinte estrutura

--- a/docs/basic-routing.md
+++ b/docs/basic-routing.md
@@ -68,3 +68,5 @@ Reply with "Hello World!" to whoever requested (*client* who made the *request*)
     ```
 
 *NOTA: A versão atual do [Lazarus 3.2.2](https://www.lazarus-ide.org/index.php?page=downloads) não tem suporte a métodos anônimos, veja o exemplo em [Olá Mundo](../hello-world) de como informar o callback no Lazarus*
+
+--8<-- "includes/abbreviations.md"

--- a/docs/hello-world.en.md
+++ b/docs/hello-world.en.md
@@ -72,3 +72,5 @@ Then open a browser, type http://localhost:9000/ in the address bar and browse t
 If you were able to view the result in your browser, this is great, your server worked correctly. Now you're ready to evolve on Horse!
 
 See more at: [Understanding routing](../basic-routing.en)
+
+--8<-- "includes/abbreviations.md"

--- a/docs/hello-world.md
+++ b/docs/hello-world.md
@@ -74,3 +74,5 @@ Então abra o browser, digite http://localhost:9000/ para acessar a sua primeira
 Agora Você está pronto para desenvolver com o Horse!
 
 Próximo passo: [Entendendo rotas](../basic-routing)
+
+--8<-- "includes/abbreviations.md"

--- a/docs/index.en.md
+++ b/docs/index.en.md
@@ -46,3 +46,5 @@ See more at:
  * [Installing](../installation.en) Horse.
  * Creating a [Hello world!](../hello-world.en).
  * Understanding [routing](../basic-routing.en).
+
+ --8<-- "includes/abbreviations.md"

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,3 +44,6 @@ Veja mais:
  * [Instalando](installation) Horse.
  * Implementando um [Olá mundo!](hello-world).
  * Entendendo [rotas](basic-routing).
+
+
+--8<-- "includes/abbreviations.md"

--- a/docs/installation.en.md
+++ b/docs/installation.en.md
@@ -24,3 +24,5 @@ $ boss install horse
 
 See more at:
   * Creating a [Hello world!](../hello-world.en).
+
+--8<-- "includes/abbreviations.md"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -25,3 +25,5 @@ $ boss install horse
 
 Veja mais em:
   * Implementando um [Olá Mundo!](../hello-world).
+
+--8<-- "includes/abbreviations.md"

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -75,3 +75,5 @@ Res.Send(AContent) | Envia uma string |
 Res.Send<T: class> | Envia um objeto |
 Res.Status(AStatus) | Configura o código do status de resposta |
 Res.ContentType(AContentType) | Configura o ContentType da resposta |
+
+--8<-- "includes/abbreviations.md"

--- a/includes/abbreviations.md
+++ b/includes/abbreviations.md
@@ -1,0 +1,2 @@
+*[URI]: Uniform Resource Identifier
+*[HTTP]: Hypertext Transfer Protocol

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,7 +43,9 @@ plugins:
           guide: "Guia"
         
       
-markdown_extensions:
+markdown_extensions:  
+  - abbr
+  - pymdownx.snippets
   - pymdownx.tasklist:
       custom_checkbox: true
   - pymdownx.superfences


### PR DESCRIPTION
For example, when typing Abbreviation like **URI** or **HTTP**, we now can add more information then external link, In this case we've added some hint when user pass the mouse over the abbreviation

*[URI]: Uniform Resource Identifier
*[HTTP]: Hypertext Transfer Protocol